### PR TITLE
fix: support nestedState for OptionsAPI and refactor

### DIFF
--- a/packages/test-project/src/components/OldApiExample.vue
+++ b/packages/test-project/src/components/OldApiExample.vue
@@ -1,18 +1,20 @@
 <template>
   <div>
-    <label>Number X</label>
+    <label>Number X ($model: {{ vv.x.$model }})</label>
     <input
       v-model.number="x"
       type="number"
     >
     <br>
-    <label>Number Y</label>
+    <label>Number Y ($model: {{ vv.y.$model }})</label>
     <input
       v-model.number="y"
       type="number"
     >
     <br>
     <p>X + Y = {{ xPlusY }}</p>
+
+    <label>Number Y+X ($model: {{ vv.xPlusY.$model }})</label>
     <div style="background: rgba(219, 53, 53, 0.62); color: #ff9090; padding: 10px 15px">
       <p
         v-for="(error, index) of vv.$errors"
@@ -23,19 +25,29 @@
       </p>
     </div>
 
-    <label>Dims</label>
-    <input
-      v-model.number="dims.w"
-      type="number"
-    >
-    <input
-      v-model.number="dims.h"
-      type="number"
-    >
-    <input
-      v-model.number="dims.l"
-      type="number"
-    >
+    <h3>Dims</h3>
+    <label>
+      x ($model: {{ vv.dims.w.$model }})
+      <input
+        v-model.number="dims.w"
+        type="number"
+      >
+    </label>
+    |
+    <label>
+      <input
+        v-model.number="dims.h"
+        type="number"
+      >
+    </label>
+    |
+    <label>
+      l ($model: {{ vv.dims.l.$model }})
+      <input
+        v-model.number="dims.l"
+        type="number"
+      >
+    </label>
 
     <button @click="vv.$touch()">
       $touch!
@@ -79,7 +91,7 @@ export default {
   //
   // },
   validations () {
-    console.log(this)
+    console.log('validation fn', this)
     return {
       x: {
         $autoDirty: true,
@@ -103,19 +115,24 @@ export default {
           $validator: (v) => v % 2 === 0,
           $message: 'Sum must be an even number'
         }
+      },
+      dims: {
+        maxVolume: {
+          $validator: (dims) => dims && dims.h ? (dims.h * dims.w * dims.l) > 0 : false,
+          $message: 'Volume must be greater than zero'
+        },
+        minVolume: {
+          $validator: (dims) => dims && dims.h ? (dims.h * dims.w * dims.l) < 12 : false,
+          $message: 'Volume must be less than 12'
+        },
+        w: {
+          $autoDirty: true,
+          minValue: minValue(2)
+        },
+        l: {
+          minValue: minValue(4)
+        }
       }
-      // dims: {
-      //   volume: {
-      //     $validator: (dims) => (dims.h * dims.w * dims.l) > 0,
-      //     $message: 'Volume must be greater than zero'
-      //   },
-      //   w: {
-      //     minValue: minValue(2)
-      //   },
-      //   l: {
-      //     minValue: minValue(4)
-      //   }
-      // }
     }
   }
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**Other information:**
- Here I am trying to resolve the issue when building the validation object in setup and data is not present yet in the component
- I refactored the code to centralize the extraction of nestedValidation once. It has extra checks in order to maintain the correct ref/reactive/computed value
- **NOTE** When using the Options API the validation function does not have access to data (as it is called at setup). For some reason, the reactivity is not working here and any change in the state will not update the validation computed object
