### PR TITLE
feat(core): run validations after data is bound

### DIFF
--- a/packages/test-project/src/components/OldApiExample.vue
+++ b/packages/test-project/src/components/OldApiExample.vue
@@ -63,6 +63,7 @@
 import { ref } from 'vue'
 import useVuelidate from '@vuelidate/core'
 import { minValue } from '@vuelidate/validators'
+import { computed } from 'vue-demi'
 
 export default {
   setup (props, context) {
@@ -91,11 +92,11 @@ export default {
   //
   // },
   validations () {
-    console.log('validation fn', this)
+    // console.log('validation fn', this)
     return {
       x: {
         $autoDirty: true,
-        minValue: minValue(this.y),
+        minValue: minValue(computed(() => this.y)),
         isEven: {
           $validator: (v) => v % 2 === 0,
           $message: 'X must be an even number'

--- a/packages/vuelidate/src/index.js
+++ b/packages/vuelidate/src/index.js
@@ -1,4 +1,4 @@
-import { computed, getCurrentInstance, inject, onBeforeMount, onBeforeUnmount, provide, ref } from 'vue-demi'
+import { watch, computed, getCurrentInstance, inject, onBeforeMount, onBeforeUnmount, provide, ref } from 'vue-demi'
 import { isFunction, unwrap } from './utils'
 import { setValidations } from './core'
 
@@ -14,29 +14,7 @@ const VuelidateRemoveChildResults = Symbol('vuelidate#removeChiildResults')
  * @return {UnwrapRef<*>}
  */
 export function useVuelidate (validations, state, globalConfig = {}) {
-  if (!validations) {
-    const instance = getCurrentInstance()
-    if (instance.type.validations) {
-      const rules = instance.type.validations
-
-      state = ref({})
-      onBeforeMount(() => {
-        // Delay binding state to validations defined with the Options API until mounting, when the data
-        // has been attached to the component instance. From that point on it will be reactive.
-        state.value = instance.proxy
-      })
-
-      validations = computed(() => isFunction(rules)
-        ? rules.call(state.value)
-        : rules
-      )
-
-      globalConfig = instance.type.validationsConfig || {}
-    }
-  }
-
   let { $registerAs } = globalConfig
-
   // if there is no registration name, add one.
   if (!$registerAs) {
     const instance = getCurrentInstance()
@@ -46,7 +24,7 @@ export function useVuelidate (validations, state, globalConfig = {}) {
     const uid = instance.uid || instance._uid
     $registerAs = `_vuelidate_${uid}`
   }
-
+  const validationResults = ref({})
   const resultsCache = new Map()
 
   const childResultsRaw = {}
@@ -85,16 +63,47 @@ export function useVuelidate (validations, state, globalConfig = {}) {
   // provide to all of it's children the remove results  function
   provide(VuelidateRemoveChildResults, removeChildResultsFromParent)
 
-  const validationResults = setValidations({
-    validations,
-    state,
-    childResults,
-    resultsCache,
-    globalConfig
-  })
+  if (!validations) {
+
+    const instance = getCurrentInstance()
+    if (instance.type.validations) {
+      const rules = instance.type.validations
+
+      state = ref({})
+      onBeforeMount(() => {
+        console.log('[beforeMount]')
+
+        // Delay binding state to validations defined with the Options API until mounting, when the data
+        // has been attached to the component instance. From that point on it will be reactive.
+        state.value = instance.proxy
+
+        validations = isFunction(rules)
+          ? rules.call(instance.proxy)
+          : rules
+
+        validationResults.value = setValidations({
+          validations,
+          state,
+          childResults,
+          resultsCache,
+          globalConfig
+        });
+      })
+
+      globalConfig = instance.type.validationsConfig || {}
+    }
+  } else {
+    validationResults.value = setValidations({
+      validations,
+      state,
+      childResults,
+      resultsCache,
+      globalConfig
+    });
+  }
 
   // send all the data to the parent when the function is invoked inside setup.
-  sendValidationResultsToParent(validationResults, $registerAs)
+  sendValidationResultsToParent(validationResults.value, $registerAs)
   // before this component is destroyed, remove all the data from the parent.
   onBeforeUnmount(() => removeValidationResultsFromParent($registerAs))
 
@@ -106,7 +115,7 @@ export function useVuelidate (validations, state, globalConfig = {}) {
   // TODO: Change into reactive + watch
   return computed(() => {
     return {
-      ...validationResults,
+      ...validationResults.value,
       ...childResults.value
     }
   })


### PR DESCRIPTION
Validations for optionsAPI should be run only after data is present. This way we can create the links for the validations rules and there is no risk of accessing properties of undefined data/computed properties

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch for v1.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuelidate/vuelidate/blob/master/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
